### PR TITLE
Updated README.md for the new token registration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you want to use the WARP client with Cloudflare Zero Trust, just start the co
 4. On the success page, right-click and select **View Page Source**.
 5. Find the HTML metadata tag that contains the token. For example, `<meta http-equiv="refresh" content"=0;url=com.cloudflare.warp://acmecorp.cloudflareaccess.com/auth?token=yeooilknmasdlfnlnsadfojDSFJndf_kjnasdf..." />`
 6. Copy the URL field: `com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=<your-token>`
-7. In the terminal, run the following command using the URL obtained in the previous step: `warp-cli teams-enroll-token com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=<your-token>`. If you get an API error, then the token has expired. Generate a new one by refreshing the web page and quickly grab the new token from the page source.
+7. In the terminal, run the following command using the URL obtained in the previous step: `warp-cli registration token com.cloudflare.warp://<your-team-name>.cloudflareaccess.com/auth?token=<your-token>`. If you get an API error, then the token has expired. Generate a new one by refreshing the web page and quickly grab the new token from the page source.
 8. `warp-cli connect` to reconnect using new registration.
 9. Wait untill `warp-cli status` shows `Connected`.
 10. Try `curl --socks5-hostname 127.0.0.1:1080 https://cloudflare.com/cdn-cgi/trace` to verify the connection.


### PR DESCRIPTION
Updated the deprecated ```warp-cli teams-enroll-token``` command to ```warp-cli registration token```