### PR TITLE
Update entrypoint.sh to ensure compatibility with Podman

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,12 @@
 # exit when any command fails
 set -e
 
-# create a tun device
-sudo mkdir -p /dev/net
-sudo mknod /dev/net/tun c 10 200
-sudo chmod 600 /dev/net/tun
+# create a tun device if not exist to ensure compatibility with Podman
+if [ ! -e /dev/net/tun ]; then
+    sudo mkdir -p /dev/net
+    sudo mknod /dev/net/tun c 10 200
+    sudo chmod 600 /dev/net/tun
+fi
 
 # start dbus
 sudo mkdir -p /run/dbus


### PR DESCRIPTION
When using Podman to run a container with the --privileged option, the error occurs: mknod: /dev/net/tun: File exists.