### PR TITLE
fix: fix binfmt(qemu) version to resolve build error

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
`docker/setup-qemu-action@v3` uses `tonistiigi/binfmt:latest` by default. However, a update in binfmt recently breaks the CI. This commit resolve the error by fixing the version of binfmt.

Ref:
- https://github.com/docker/buildx/issues/314
- https://github.com/tonistiigi/binfmt/issues/240#issuecomment-2668618554
- https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2644856279